### PR TITLE
Potential fix for code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "ts-fsrs": "^5.2.3",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "dompurify": "^3.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/lib/clipboard/note-content.ts
+++ b/src/lib/clipboard/note-content.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import DOMPurify from "dompurify";
+
 export type NoteCopyFormat = "plain" | "rich";
 
 /**
@@ -12,7 +14,8 @@ export async function copyNoteContentToClipboard(
   html: string,
   format: NoteCopyFormat,
 ) {
-  const plainText = getPlainTextFromHtml(html);
+  const sanitizedHtml = sanitizeRichHtmlForClipboard(html);
+  const plainText = getPlainTextFromHtml(sanitizedHtml);
 
   if (format === "plain" || !canCopyRichText()) {
     await navigator.clipboard.writeText(plainText);
@@ -21,7 +24,7 @@ export async function copyNoteContentToClipboard(
 
   await navigator.clipboard.write([
     new ClipboardItem({
-      "text/html": new Blob([html], { type: "text/html" }),
+      "text/html": new Blob([sanitizedHtml], { type: "text/html" }),
       "text/plain": new Blob([plainText], { type: "text/plain" }),
     }),
   ]);
@@ -32,6 +35,10 @@ function canCopyRichText() {
     typeof ClipboardItem !== "undefined" &&
     typeof navigator.clipboard?.write === "function"
   );
+}
+
+function sanitizeRichHtmlForClipboard(html: string): string {
+  return DOMPurify.sanitize(html);
 }
 
 function getPlainTextFromHtml(html: string): string {


### PR DESCRIPTION
Potential fix for [https://github.com/joaogiacometti/notorium/security/code-scanning/17](https://github.com/joaogiacometti/notorium/security/code-scanning/17)

Use a robust HTML sanitizer before both:
1) parsing for plain-text extraction, and  
2) writing `"text/html"` to the clipboard.

Best fix (without changing intended behavior):
- In `src/lib/clipboard/note-content.ts`, sanitize incoming `html` once at the start of `copyNoteContentToClipboard`.
- Use that sanitized value for `getPlainTextFromHtml(...)` and for the `"text/html"` clipboard blob.
- This keeps rich-copy functionality, but strips dangerous tags/attributes/protocols.
- Add a well-known sanitizer import (`dompurify`) and create a small helper (`sanitizeRichHtmlForClipboard`) for clarity and reuse.

No changes are required in `src/components/notes/note-detail.tsx`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
