### PR TITLE
chore(ci): add architecture, file-size, and coverage guards

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,5 +44,8 @@ jobs:
       - name: Type check (TypeScript)
         run: bun run typecheck
 
-      - name: Tests (Vitest)
-        run: bun run test
+      - name: Tests & coverage thresholds (Vitest)
+        run: bun run test:coverage
+
+      - name: File-size guard
+        run: bun run check:size

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This file is for agents. Keep it short, direct, imperative, and focused on what 
 ## Code Style
 
 - Functions: 4-20 lines. Split if longer.
-- Files: under 500 lines. Split by responsibility.
+- Files: under 500 lines. Split by responsibility. Enforced by `bun run check:size` (see Automated Guards).
 - One thing per function, one responsibility per module.
 - Names: specific and unique. Avoid `data`, `handler`, `Manager`, and other vague names.
 - Prefer names that return fewer than 5 grep hits in the codebase.
@@ -85,7 +85,8 @@ Only add optional files when they are needed.
 - Server Components read from `src/features/*` directly.
 - Do not call Server Actions from Server Components.
 - Keep Server Actions thin: authenticate, validate, delegate, revalidate, return typed result.
-- `src/app/actions/*` must not import `@/db/index` directly unless the exception is documented.
+- `src/app/actions/*` must not import `@/db/index` directly unless the exception is documented. Lint-enforced; document a genuine exception with a `biome-ignore` comment and reason.
+- `src/components/*` must not import `@/features/*/mutations`. Writes go through Server Actions. Lint-enforced.
 - Keep read logic in `src/features/*/queries.ts`.
 - Keep write logic in `src/features/*/mutations.ts`.
 - Keep validation schemas in `src/features/*/validation.ts` or `src/lib/validations/*`.
@@ -193,6 +194,14 @@ className =
 - Add a body when the reason is not obvious. Explain what changed and why; do not restate the diff.
 - Stage only files that belong to the requested change. Do not include unrelated worktree changes.
 - Before reporting success, confirm the commit hash and a clean `git status --short`.
+
+## Automated Guards
+
+These run in CI (`.github/workflows/checks.yml`) and locally. Do not weaken a guard to make a build pass; fix the code.
+
+- `bun run lint` (Biome) also enforces architecture boundaries via `noRestrictedImports` overrides in `biome.json`: Server Actions cannot import `@/db/index`; components cannot import `@/features/*/mutations`.
+- `bun run check:size` fails on source files over 500 lines (`scripts/check-file-size.ts`). Pre-existing offenders are grandfathered in a `KNOWN_OVERSIZED` allow-list and may only shrink; never add entries.
+- `bun run test:coverage` enforces coverage floors set in `vitest.config.ts`. Ratchet them up as coverage improves; never lower them.
 
 ## Definition of Done
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The first account created on a new instance becomes an approved admin automatica
 | `bun dev` | Start the Next.js development server |
 | `bun run db:migrate` | Apply Drizzle migrations |
 | `bun run test` | Run the Vitest suite |
-| `bun run lint` | Run Biome checks |
+| `bun run test:coverage` | Run tests and enforce coverage thresholds |
+| `bun run lint` | Run Biome checks, including architecture boundaries |
+| `bun run check:size` | Fail on source files over 500 lines |
 
 ## More Docs
 

--- a/biome.json
+++ b/biome.json
@@ -38,5 +38,44 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/app/actions/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@/db/index": "Server Actions must not import @/db/index directly; read/write through src/features/*. If an exception is unavoidable, document it with a biome-ignore comment and the reason."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/components/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["@/features/*/mutations"],
+                    "message": "Components must not import feature mutations directly; writes go through Server Actions in src/app/actions/*."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,3 +46,12 @@ Scheduled Workflow -> src/app/api/* -> auth/config checks -> src/features/* serv
 Cross-cutting services live behind project-owned helpers in `src/lib/`, including Better Auth, AI providers, email, media storage, and rate limiting.
 
 The rich-text editor and read-only renderer (`src/components/shared/tiptap-editor.tsx` and `tiptap-renderer.tsx`) share their Tiptap extension sets through `src/lib/editor/build*Extensions()` helpers (tables, math). Both surfaces must register the same extensions: Tiptap drops unknown nodes when parsing stored HTML, so math or tables present only in the editor would vanish in the renderer. Math nodes (KaTeX) serialize their LaTeX into a `data-latex` attribute, which `src/lib/editor/rich-text.ts` surfaces as text so equations stay searchable and within length limits.
+
+## Enforced Boundaries
+
+Two boundaries above are machine-checked, not just convention (see the Automated Guards section in [AGENTS.md](../AGENTS.md)):
+
+- Server Actions (`src/app/actions/*`) cannot import `@/db/index`; they go through `src/features/*`. Enforced by a `noRestrictedImports` override in `biome.json`.
+- Components (`src/components/*`) cannot import `@/features/*/mutations`; writes flow through Server Actions. Enforced by the same rule. Server Components reading from `queries.ts` live under `src/app/*`, so they are unaffected.
+
+A separate guard, `bun run check:size`, keeps files under 500 lines.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome format --write",
+    "check:size": "bun scripts/check-file-size.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/scripts/check-file-size.ts
+++ b/scripts/check-file-size.ts
@@ -1,0 +1,103 @@
+/**
+ * File-size guard. Enforces the "files under 500 lines" rule from CLAUDE.md so
+ * large modules can't creep in unnoticed as the codebase grows.
+ *
+ * Run with `bun run check:size`. Exits non-zero (failing CI) when a source file
+ * exceeds its limit. New oversized files are blocked outright; the handful of
+ * pre-existing offenders are grandfathered via KNOWN_OVERSIZED and may only
+ * shrink, never grow.
+ *
+ * @example
+ *   bun run check:size
+ *   // -> "src/components/foo.tsx: 540 lines (limit 500)" then exit 1
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SOURCE_ROOT = "src";
+const DEFAULT_LIMIT = 500;
+// Test files describe many scenarios and are allowed to run longer.
+const TEST_LIMIT = 800;
+
+/**
+ * Tech-debt allow-list of files that already exceeded the limit when the guard
+ * was introduced. Do NOT add entries: split the file and remove its line here
+ * instead. Each file may only shrink — the guard fails if it grows past the
+ * recorded count, ratcheting the codebase smaller over time.
+ */
+const KNOWN_OVERSIZED: Record<string, number> = {
+  // Declarative Drizzle schema; split by table is a larger refactor.
+  "src/db/schema.ts": 753,
+  "src/components/subjects/subjects-list.tsx": 852,
+  "src/components/planning/planning-assessments-table.tsx": 567,
+  "src/components/flashcards/dialogs/edit-flashcard-dialog.tsx": 536,
+  "src/components/shared/manager-data-table.tsx": 534,
+  "src/components/shared/calendar-view.tsx": 527,
+  "src/components/flashcards/review/flashcard-review-client.tsx": 518,
+  "src/components/decks/deck-tree-sidebar.tsx": 510,
+};
+
+type Violation = { file: string; lines: number; limit: number };
+
+function isTestFile(path: string): boolean {
+  return /\.test\.tsx?$/.test(path);
+}
+
+function listSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      files.push(...listSourceFiles(path));
+      continue;
+    }
+    if (/\.tsx?$/.test(entry)) files.push(path);
+  }
+  return files;
+}
+
+// Count newlines so the result matches `wc -l`, which the allow-list caps were
+// recorded with.
+function countLines(path: string): number {
+  const content = readFileSync(path, "utf8");
+  const newlines = content.split("\n").length - 1;
+  return content.endsWith("\n") ? newlines : newlines + 1;
+}
+
+function limitFor(file: string): number {
+  const cap = KNOWN_OVERSIZED[file];
+  if (cap !== undefined) return cap;
+  return isTestFile(file) ? TEST_LIMIT : DEFAULT_LIMIT;
+}
+
+function findViolations(): Violation[] {
+  const violations: Violation[] = [];
+  for (const file of listSourceFiles(SOURCE_ROOT)) {
+    const lines = countLines(file);
+    const limit = limitFor(file);
+    if (lines > limit) violations.push({ file, lines, limit });
+  }
+  return violations;
+}
+
+function report(violations: Violation[]): void {
+  if (violations.length === 0) {
+    console.log("File-size guard: all source files within limits.");
+    return;
+  }
+  console.error("File-size guard failed:\n");
+  for (const { file, lines, limit } of violations) {
+    const grandfathered = file in KNOWN_OVERSIZED;
+    const hint = grandfathered
+      ? `exceeds its allow-listed cap of ${limit} — it must shrink, not grow`
+      : `exceeds the ${limit}-line limit — split it by responsibility`;
+    console.error(`  ${file}: ${lines} lines (${hint})`);
+  }
+  console.error(
+    "\nSplit the file into focused modules. Do not raise limits to pass.",
+  );
+}
+
+const violations = findViolations();
+report(violations);
+process.exit(violations.length > 0 ? 1 : 0);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,15 @@ export default defineConfig({
         "src/app/**",
         "src/env.ts",
       ],
+      // Floors set ~5pts below the measured baseline (2026-06): they guard
+      // against regression, not to force a coverage sprint. Ratchet up as
+      // coverage improves; never lower to make a red build pass.
+      thresholds: {
+        statements: 47,
+        branches: 43,
+        functions: 44,
+        lines: 47,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
Turn three documented conventions into enforced checks so quality can't silently rot as the codebase grows:

- biome: noRestrictedImports overrides forbid actions importing @/db/index and components importing @/features/*/mutations.
- scripts/check-file-size.ts fails on source files over 500 lines, with a shrink-only allow-list for pre-existing offenders.
- vitest coverage thresholds set ~5pts under the current baseline.

Wire test:coverage and check:size into the Checks workflow and document the guards in AGENTS.md, README.md, and architecture.md.